### PR TITLE
Simplify repository implementation

### DIFF
--- a/app/src/main/java/com/onwordiesquire/android/githubsearch/data/datasource/RemoteDataSource.kt
+++ b/app/src/main/java/com/onwordiesquire/android/githubsearch/data/datasource/RemoteDataSource.kt
@@ -5,7 +5,6 @@ import io.reactivex.Single
 import retrofit2.Response
 import retrofit2.http.GET
 import retrofit2.http.Query
-import javax.inject.Inject
 
 interface GithubApi {
 
@@ -14,12 +13,6 @@ interface GithubApi {
                                @Query("page") page: Int,
                                @Query("per_page") pageSize: Int)
             : Single<Response<SearchResponseDto>>
-}
-
-class RemoteDataSource @Inject constructor(private val githubApi: GithubApi) {
-
-    fun searchForRepositories(searchTerm: String, pageNo: Int = 0, pageSize: Int)
-            : Single<Response<SearchResponseDto>> = githubApi.searchForRespositories(searchTerm, pageNo, pageSize)
 }
 
 sealed class DataSourceResponse<T> {

--- a/app/src/main/java/com/onwordiesquire/android/githubsearch/data/repository/DataRepositoryImpl.kt
+++ b/app/src/main/java/com/onwordiesquire/android/githubsearch/data/repository/DataRepositoryImpl.kt
@@ -1,18 +1,20 @@
 package com.onwordiesquire.android.githubsearch.data.repository
 
 import com.onwordiesquire.android.githubsearch.data.datasource.DataSourceResponse
+import com.onwordiesquire.android.githubsearch.data.datasource.GithubApi
 import com.onwordiesquire.android.githubsearch.data.datasource.PAGE_SIZE
-import com.onwordiesquire.android.githubsearch.data.datasource.RemoteDataSource
 import com.onwordiesquire.android.githubsearch.data.dto.SearchResponseDto
 import io.reactivex.Single
 import javax.inject.Inject
-import javax.inject.Singleton
 
-@Singleton
-class DataRepository @Inject constructor(private val remoteDataSource: RemoteDataSource) {
+interface DataRepository {
+    fun searchForRepository(searchTerm: String, pageSize: Int = PAGE_SIZE, pageNo: Int): Single<DataSourceResponse<SearchResponseDto>>
+}
 
-    fun searchForRepository(searchTerm: String, pageSize: Int = PAGE_SIZE, pageNo: Int): Single<DataSourceResponse<SearchResponseDto>> =
-            remoteDataSource.searchForRepositories(searchTerm, pageNo, pageSize).map { response ->
+class DataRepositoryImpl @Inject constructor(private val githubApi: GithubApi) : DataRepository {
+
+    override fun searchForRepository(searchTerm: String, pageSize: Int, pageNo: Int): Single<DataSourceResponse<SearchResponseDto>> =
+            githubApi.searchForRespositories(searchTerm, pageNo, pageSize).map { response ->
                 with(response) {
                     when {
                         isSuccessful -> DataSourceResponse.Success(payload = body(), headers = headers().toMultimap())

--- a/app/src/main/java/com/onwordiesquire/android/githubsearch/di/component/MainComponent.kt
+++ b/app/src/main/java/com/onwordiesquire/android/githubsearch/di/component/MainComponent.kt
@@ -4,6 +4,7 @@ import com.onwordiesquire.android.githubsearch.GithubSearchApp
 import com.onwordiesquire.android.githubsearch.di.modules.BuildersModule
 import com.onwordiesquire.android.githubsearch.di.modules.GitHubApiModule
 import com.onwordiesquire.android.githubsearch.di.modules.NetworkModule
+import com.onwordiesquire.android.githubsearch.di.modules.RepositoryModule
 import com.onwordiesquire.android.githubsearch.di.modules.ViewModelFactoryModule
 import com.onwordiesquire.android.githubsearch.di.modules.ViewModelModule
 import dagger.BindsInstance
@@ -17,6 +18,7 @@ import javax.inject.Singleton
     ViewModelFactoryModule::class,
     BuildersModule::class,
     ViewModelModule::class,
+    RepositoryModule::class,
     AndroidSupportInjectionModule::class])
 interface MainComponent {
     fun inject(githubSearchApp: GithubSearchApp)

--- a/app/src/main/java/com/onwordiesquire/android/githubsearch/di/modules/RepositoryModule.kt
+++ b/app/src/main/java/com/onwordiesquire/android/githubsearch/di/modules/RepositoryModule.kt
@@ -1,0 +1,13 @@
+package com.onwordiesquire.android.githubsearch.di.modules
+
+import com.onwordiesquire.android.githubsearch.data.repository.DataRepository
+import com.onwordiesquire.android.githubsearch.data.repository.DataRepositoryImpl
+import dagger.Binds
+import dagger.Module
+
+@Module
+abstract class RepositoryModule {
+
+    @Binds
+    abstract fun provideDataRepository(repositoryImpl: DataRepositoryImpl): DataRepository
+}


### PR DESCRIPTION
For this use-case, the remote data source class provided no actual benefit,
it just added more complexity thus making development a tad bit slower.
For a cleaner mental model and faster development, while still maintaining
the benefits of the repository pattern, i've opted to remove it and create
an interface to represent the repository. Using dagger a concrete implementation
of this interface will be provided to the object graph.